### PR TITLE
Pickup eh_frame on AArch64 commit for LLVM 13

### DIFF
--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -58,9 +58,10 @@ void MCObjectFileInfo::initMachOMCObjectFileInfo(const Triple &T) {
           MachO::S_ATTR_STRIP_STATIC_SYMS | MachO::S_ATTR_LIVE_SUPPORT,
       SectionKind::getReadOnly());
 
-  if (T.isOSDarwin() &&
-      (T.getArch() == Triple::aarch64 || T.getArch() == Triple::aarch64_32))
-    SupportsCompactUnwindWithoutEHFrame = true;
+  // Disabled for now, since we need to emit EH Frames for stack unwinding in the JIT
+  // if (T.isOSDarwin() &&
+  //     (T.getArch() == Triple::aarch64 || T.getArch() == Triple::aarch64_32))
+  //   SupportsCompactUnwindWithoutEHFrame = true;
 
   if (T.isWatchABI())
     OmitDwarfIfHaveCompactUnwind = true;


### PR DESCRIPTION
@dnadlinger noticed that it was missing while, working on improving M1 support.

@keno @vtjnash do either of you remember why I might have dropped this?

