### PR TITLE
Backport JITLink fix from LLVM main

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/MachOLinkGraphBuilder.h
@@ -125,13 +125,12 @@ protected:
   /// given index is out of range, or if no symbol has been added for the given
   /// index.
   Expected<NormalizedSymbol &> findSymbolByIndex(uint64_t Index) {
-    if (Index >= IndexToSymbol.size())
-      return make_error<JITLinkError>("Symbol index out of range");
-    auto *Sym = IndexToSymbol[Index];
-    if (!Sym)
+    auto I = IndexToSymbol.find(Index);
+    if (I == IndexToSymbol.end())
       return make_error<JITLinkError>("No symbol at index " +
                                       formatv("{0:d}", Index));
-    return *Sym;
+    assert(I->second && "Null symbol at index");
+    return *I->second;
   }
 
   /// Returns the symbol with the highest address not greater than the search


### PR DESCRIPTION
This backports
```
commit 91434d44699642075378c888bf61715ff2d9e23f (refs/bisect/new)
Author: Lang Hames <lhames@gmail.com>
Date:   Tue Oct 26 18:32:06 2021 -0700

    [JITLink] Fix element-present check in MachOLinkGraphParser.

    Not all symbols are added to the index-to-symbol map, so we shouldn't use the
    size of the map as a proxy for the highest valid index.
```
from upstream `main` onto our 13.x release branch.

Without it, JITLink, which we need to fix the aarch64-darwin (macOS/ARM64) segfaults, is completely unusable; the issue is hit immediately during system image creation.