### PR TITLE
The msan patch broke macos, fix it.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_tls_get_addr.cpp
@@ -16,7 +16,9 @@
 #include "sanitizer_flags.h"
 #include "sanitizer_platform_interceptors.h"
 
+#if !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 namespace __sanitizer {
 #if SANITIZER_INTERCEPT_TLS_GET_ADDR


### PR DESCRIPTION
The patch broke on macos because malloc.h doesn't exist there
