### PR TITLE
Don't build MLIRExecutionEngineShared on Windows (Backport https://github.com/llvm/llvm-project/pull/109524 to 19.x)

### DIFF
--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -97,7 +97,7 @@ add_mlir_library(MLIRExecutionEngine
   MLIRTargetLLVMIRExport
   )
 
-if(LLVM_BUILD_LLVM_DYLIB)
+if(LLVM_BUILD_LLVM_DYLIB AND NOT (WIN32 OR MINGW OR CYGWIN))
   # Build a shared library for the execution engine. Some downstream projects
   # use this library to build their own CPU runners while preserving dynamic
   # linkage.


### PR DESCRIPTION
It doesn't currently build on windows, see https://github.com/llvm/llvm-project/issues/106859.