### PR TITLE
Backport [MLIR][IRDL][CMake] Switch to using `setup_host_tool` to fix cross compilation (#156606)

### DIFF
--- a/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
+++ b/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
@@ -6,23 +6,4 @@ mlir_target_link_libraries(mlir-irdl-to-cpp
   MLIRTargetIRDLToCpp
   )
 
-# Set up a native build when cross-compiling.
-if(LLVM_USE_HOST_TOOLS)
-  build_native_tool(
-    mlir-irdl-to-cpp
-    MLIR_IRDL_TO_CPP_EXE
-
-    # Native tool must depend on target tool so that the native tool gets
-    # properly rebuilt when the target tool changes.
-    DEPENDS mlir-irdl-to-cpp
-  )
-  add_custom_target(mlir-irdl-to-cpp-host DEPENDS ${MLIR_IRDL_TO_CPP_EXE})
-  set(MLIR_IRDL_TO_CPP_TARGET mlir-irdl-to-cpp-host)
-else()
-  set(MLIR_IRDL_TO_CPP_EXE $<TARGET_FILE:mlir-irdl-to-cpp>)
-  set(MLIR_IRDL_TO_CPP_TARGET mlir-irdl-to-cpp)
-endif()
-
-# Save the executable path and target name to the cache to expose it globally.
-set(MLIR_IRDL_TO_CPP_EXE "${MLIR_IRDL_TO_CPP_EXE}" CACHE INTERNAL "")
-set(MLIR_IRDL_TO_CPP_TARGET "${MLIR_IRDL_TO_CPP_TARGET}" CACHE INTERNAL "")
+setup_host_tool(mlir-irdl-to-cpp MLIR_IRDL_TO_CPP MLIR_IRDL_TO_CPP_EXE MLIR_IRDL_TO_CPP_TARGET)


### PR DESCRIPTION
Using `build_native_tool` directly doesn't seem to be standard, instead other tools seem to call `setup_host_tool` (e.g. milr-linalg-ods-gen and `add_tablegen` seems to have a copy of `setup_host_tool` internally).

When cross compiling llvm in two stages, the first building all native tools and then the second using those built tools to cross compile, this prevents the second stage from trying to rebuild mlir-irdl-to-cpp, which fails.

(cherry picked from commit f5006e043143717e2e8ade9a009e1209b4a3563b)