### PR TITLE
Add back manual locking ThreadSafeContext API

### DIFF
--- a/llvm/include/llvm-c/Orc.h
+++ b/llvm/include/llvm-c/Orc.h
@@ -1100,6 +1100,12 @@ LLVM_C_ABI LLVMOrcThreadSafeContextRef
 LLVMOrcCreateNewThreadSafeContextFromLLVMContext(LLVMContextRef Ctx);
 
 /**
+ * Get a reference to the wrapped LLVMContext.
+ */
+LLVMContextRef
+LLVMOrcThreadSafeContextGetContext(LLVMOrcThreadSafeContextRef TSCtx);
+
+/**
  * Dispose of a ThreadSafeContext.
  */
 LLVM_C_ABI void

--- a/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
@@ -36,6 +36,16 @@ private:
   };
 
 public:
+  // RAII based lock for ThreadSafeContext.
+  class [[nodiscard]] Lock {
+  public:
+    Lock(std::shared_ptr<State> S) : S(std::move(S)), L(this->S->Mutex) {}
+
+  private:
+    std::shared_ptr<State> S;
+    std::unique_lock<std::recursive_mutex> L;
+  };
+
   /// Construct a null context.
   ThreadSafeContext() = default;
 
@@ -60,6 +70,19 @@ public:
       return F(const_cast<const LLVMContext *>(TmpS->Ctx.get()));
     } else
       return F((const LLVMContext *)nullptr);
+  }
+
+  /// Returns a pointer to the LLVMContext that was used to construct this
+  /// instance, or null if the instance was default constructed.
+  LLVMContext *getContext() { return S ? S->Ctx.get() : nullptr; }
+
+  /// Returns a pointer to the LLVMContext that was used to construct this
+  /// instance, or null if the instance was default constructed.
+  const LLVMContext *getContext() const { return S ? S->Ctx.get() : nullptr; }
+
+  Lock getLock() const {
+    assert(S && "Can not lock an empty ThreadSafeContext");
+    return Lock(S);
   }
 
 private:

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -734,6 +734,11 @@ LLVMOrcCreateNewThreadSafeContextFromLLVMContext(LLVMContextRef Ctx) {
   return wrap(new ThreadSafeContext(std::unique_ptr<LLVMContext>(unwrap(Ctx))));
 }
 
+LLVMContextRef
+LLVMOrcThreadSafeContextGetContext(LLVMOrcThreadSafeContextRef TSCtx) {
+  return wrap(unwrap(TSCtx)->getContext());
+}
+
 void LLVMOrcDisposeThreadSafeContext(LLVMOrcThreadSafeContextRef TSCtx) {
   delete unwrap(TSCtx);
 }


### PR DESCRIPTION
It is difficult to remove the use of this in julia ATM.

The new LLVM API is quite restrictive. Not sure if this is a change that should be upstreamed.
