### PR TITLE
DILocation: Support 32-bit column number

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -2501,14 +2501,14 @@ public:
 ///
 /// A debug location in source code, used for debug info and otherwise.
 ///
-/// Uses the SubclassData1, SubclassData16 and SubclassData32
-/// Metadata slots.
+/// Uses the SubclassData1 and SubclassData32 Metadata slots.
 
 class DILocation : public MDNode {
   friend class LLVMContextImpl;
   friend class MDNode;
+  uint64_t Column : 32;
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
-  uint64_t AtomGroup : 61;
+  uint64_t AtomGroup : 29;
   uint64_t AtomRank : 3;
 #endif
 
@@ -2582,7 +2582,7 @@ public:
   TempDILocation clone() const { return cloneImpl(); }
 
   unsigned getLine() const { return SubclassData32; }
-  unsigned getColumn() const { return SubclassData16; }
+  unsigned getColumn() const { return Column; }
   DILocalScope *getScope() const { return cast<DILocalScope>(getRawScope()); }
 
   /// Return the linkage name of Subprogram. If the linkage name is empty,
@@ -2832,14 +2832,13 @@ class DILexicalBlock : public DILexicalBlockBase {
   friend class LLVMContextImpl;
   friend class MDNode;
 
-  uint16_t Column;
+  uint32_t Column;
 
   DILexicalBlock(LLVMContext &C, StorageType Storage, unsigned Line,
                  unsigned Column, ArrayRef<Metadata *> Ops)
       : DILexicalBlockBase(C, DILexicalBlockKind, Storage, Ops),
         Column(Column) {
     SubclassData32 = Line;
-    assert(Column < (1u << 16) && "Expected 16-bit column");
   }
   ~DILexicalBlock() = default;
 

--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -106,7 +106,7 @@ struct MCDwarfFile {
 class MCDwarfLoc {
   uint32_t FileNum;
   uint32_t Line;
-  uint16_t Column;
+  uint32_t Column;
   // Flags (see #define's below)
   uint8_t Flags;
   uint8_t Isa;
@@ -158,10 +158,7 @@ public:
   void setLine(unsigned line) { Line = line; }
 
   /// Set the Column of this MCDwarfLoc.
-  void setColumn(unsigned column) {
-    assert(column <= UINT16_MAX);
-    Column = column;
-  }
+  void setColumn(unsigned column) { Column = column; }
 
   /// Set the Flags of this MCDwarfLoc.
   void setFlags(unsigned flags) {

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4697,7 +4697,7 @@ struct LineField : public MDUnsignedField {
 };
 
 struct ColumnField : public MDUnsignedField {
-  ColumnField() : MDUnsignedField(0, UINT16_MAX) {}
+  ColumnField() : MDUnsignedField(0, UINT32_MAX) {}
 };
 
 struct DwarfTagField : public MDUnsignedField {

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -246,9 +246,13 @@ CodeViewDebug::getInlineSite(const DILocation *InlinedAt,
               .SiteFuncId;
 
     Site->SiteFuncId = NextFuncId++;
+    // CodeView columns are 16 bits; record 0 ("unknown") if it doesn't fit.
+    unsigned IAColumn = InlinedAt->getColumn();
+    if (IAColumn > UINT16_MAX)
+      IAColumn = 0;
     OS.emitCVInlineSiteIdDirective(
         Site->SiteFuncId, ParentFuncId, maybeRecordFile(InlinedAt->getFile()),
-        InlinedAt->getLine(), InlinedAt->getColumn(), SMLoc());
+        InlinedAt->getLine(), IAColumn, SMLoc());
     Site->Inlinee = Inlinee;
     InlinedSubprograms.insert(Inlinee);
     auto InlineeIdx = getFuncIdForSubprogram(Inlinee);
@@ -523,9 +527,11 @@ void CodeViewDebug::maybeRecordLocation(const DebugLoc &DL,
       LI.isNeverStepInto())
     return;
 
-  ColumnInfo CI(DL.getCol(), /*EndColumn=*/0);
-  if (CI.getStartColumn() != DL.getCol())
-    return;
+  // CodeView column numbers are limited to 16 bits. If the column number does
+  // not fit, record it as 0 ("unknown") rather than dropping the location.
+  unsigned Column = DL.getCol();
+  if (Column > UINT16_MAX)
+    Column = 0;
 
   if (!CurFn->HaveLineInfo)
     CurFn->HaveLineInfo = true;
@@ -558,7 +564,7 @@ void CodeViewDebug::maybeRecordLocation(const DebugLoc &DL,
     addLocIfNotPresent(CurFn->ChildSites, Loc);
   }
 
-  OS.emitCVLocDirective(FuncId, FileId, DL.getLine(), DL.getCol(),
+  OS.emitCVLocDirective(FuncId, FileId, DL.getLine(), Column,
                         /*PrologueEnd=*/false, /*IsStmt=*/false,
                         DL->getFilename(), SMLoc());
 }

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -66,7 +66,7 @@ DebugVariableAggregate::DebugVariableAggregate(const DbgVariableIntrinsic *DVI)
 DILocation::DILocation(LLVMContext &C, StorageType Storage, unsigned Line,
                        unsigned Column, uint64_t AtomGroup, uint8_t AtomRank,
                        ArrayRef<Metadata *> MDs, bool ImplicitCode)
-    : MDNode(C, DILocationKind, Storage, MDs)
+    : MDNode(C, DILocationKind, Storage, MDs), Column(Column)
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
       ,
       AtomGroup(AtomGroup), AtomRank(AtomRank)
@@ -74,25 +74,18 @@ DILocation::DILocation(LLVMContext &C, StorageType Storage, unsigned Line,
 {
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
   assert(AtomRank <= 7 && "AtomRank number should fit in 3 bits");
+  assert(AtomGroup < (1ULL << 29) && "AtomGroup number should fit in 29 bits");
 #endif
   if (AtomGroup)
     C.updateDILocationAtomGroupWaterline(AtomGroup + 1);
 
   assert((MDs.size() == 1 || MDs.size() == 2) &&
          "Expected a scope and optional inlined-at");
-  // Set line and column.
-  assert(Column < (1u << 16) && "Expected 16-bit column");
-
+  // Set line. The column is stored in the dedicated 32-bit Column field via the
+  // member initializer above.
   SubclassData32 = Line;
-  SubclassData16 = Column;
 
   setImplicitCode(ImplicitCode);
-}
-
-static void adjustColumn(unsigned &Column) {
-  // Set to unknown on overflow.  We only have 16 bits to play with here.
-  if (Column >= (1u << 16))
-    Column = 0;
 }
 
 DILocation *DILocation::getImpl(LLVMContext &Context, unsigned Line,
@@ -100,9 +93,6 @@ DILocation *DILocation::getImpl(LLVMContext &Context, unsigned Line,
                                 Metadata *InlinedAt, bool ImplicitCode,
                                 uint64_t AtomGroup, uint8_t AtomRank,
                                 StorageType Storage, bool ShouldCreate) {
-  // Fixup column.
-  adjustColumn(Column);
-
   if (Storage == Uniqued) {
     if (auto *N = getUniqued(Context.pImpl->DILocations,
                              DILocationInfo::KeyTy(Line, Column, Scope,
@@ -1444,9 +1434,6 @@ DILexicalBlock *DILexicalBlock::getImpl(LLVMContext &Context, Metadata *Scope,
                                         Metadata *File, unsigned Line,
                                         unsigned Column, StorageType Storage,
                                         bool ShouldCreate) {
-  // Fixup column.
-  adjustColumn(Column);
-
   assert(Scope && "Expected scope");
   DEFINE_GETIMPL_LOOKUP(DILexicalBlock, (Scope, File, Line, Column));
   Metadata *Ops[] = {File, Scope};

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -313,14 +313,14 @@ template <> struct MDNodeKeyImpl<DILocation> {
   Metadata *Scope;
   Metadata *InlinedAt;
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
-  uint64_t AtomGroup : 61;
+  uint64_t AtomGroup : 29;
   uint64_t AtomRank : 3;
 #endif
   unsigned Line;
-  uint16_t Column;
+  unsigned Column;
   bool ImplicitCode;
 
-  MDNodeKeyImpl(unsigned Line, uint16_t Column, Metadata *Scope,
+  MDNodeKeyImpl(unsigned Line, unsigned Column, Metadata *Scope,
                 Metadata *InlinedAt, bool ImplicitCode, uint64_t AtomGroup,
                 uint8_t AtomRank)
       : Scope(Scope), InlinedAt(InlinedAt),
@@ -352,6 +352,7 @@ template <> struct MDNodeKeyImpl<DILocation> {
   }
 
   unsigned getHashValue() const {
+    uint64_t LineAndColumn = uint64_t(Line) | (uint64_t(Column) << 32);
 #ifdef EXPERIMENTAL_KEY_INSTRUCTIONS
     // Hashing AtomGroup and AtomRank substantially impacts performance whether
     // Key Instructions is enabled or not. We can't detect whether it's enabled
@@ -361,10 +362,10 @@ template <> struct MDNodeKeyImpl<DILocation> {
     // outweighed by the overall compile time savings by performing this check.
     // * (hash_combine(x) != hash_combine(x, 0))
     if (AtomGroup || AtomRank)
-      return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode,
-                          AtomGroup, (uint8_t)AtomRank);
+      return hash_combine(LineAndColumn, ImplicitCode, Scope, InlinedAt,
+                          AtomGroup | (uint64_t(AtomRank) << 29));
 #endif
-    return hash_combine(Line, Column, Scope, InlinedAt, ImplicitCode);
+    return hash_combine(LineAndColumn, ImplicitCode, Scope, InlinedAt);
   }
 };
 

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -1634,6 +1634,21 @@ TEST_F(DILocationTest, getDistinct) {
   EXPECT_EQ(L1, DILocation::get(Context, 2, 7, N));
 }
 
+TEST_F(DILocationTest, WideColumn) {
+  MDNode *N = getSubprogram();
+  // Column numbers wider than 16 bits are preserved (up to 32 bits) rather
+  // than being clamped to zero.
+  DILocation *L = DILocation::get(Context, 2, 0x10000, N);
+  EXPECT_EQ(0x10000u, L->getColumn());
+
+  DILocation *Max = DILocation::get(Context, 2, UINT32_MAX, N);
+  EXPECT_EQ(UINT32_MAX, Max->getColumn());
+
+  // Distinct columns produce distinct (and uniqued) nodes.
+  EXPECT_EQ(L, DILocation::get(Context, 2, 0x10000, N));
+  EXPECT_NE(L, Max);
+}
+
 TEST_F(DILocationTest, getTemporary) {
   MDNode *N = MDNode::get(Context, {});
   auto L = DILocation::getTemporary(Context, 2, 7, N);


### PR DESCRIPTION
Motivated by https://github.com/JuliaLang/julia/pull/61699 / https://github.com/JuliaLang/julia/pull/53925

This allows Julia to recover DebugInfo indices from the DWARF column for functions with > 65k IR statements.
Functions of that length are not terribly uncommon, so we likely want to carry this patch even though upstream probably won't be very interested in it.