### PR TITLE
[VectorCombine] Fix transitive Uses in foldShuffleToIdentity (#188989)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2621,24 +2621,24 @@ bool VectorCombine::foldShuffleOfIntrinsics(Instruction &I) {
   return true;
 }
 
-using InstLane = std::pair<Use *, int>;
+using InstLane = std::pair<Value *, int>;
 
-static InstLane lookThroughShuffles(Use *U, int Lane) {
-  while (auto *SV = dyn_cast<ShuffleVectorInst>(U->get())) {
+static InstLane lookThroughShuffles(Value *V, int Lane) {
+  while (auto *SV = dyn_cast<ShuffleVectorInst>(V)) {
     unsigned NumElts =
         cast<FixedVectorType>(SV->getOperand(0)->getType())->getNumElements();
     int M = SV->getMaskValue(Lane);
     if (M < 0)
       return {nullptr, PoisonMaskElem};
     if (static_cast<unsigned>(M) < NumElts) {
-      U = &SV->getOperandUse(0);
+      V = SV->getOperand(0);
       Lane = M;
     } else {
-      U = &SV->getOperandUse(1);
+      V = SV->getOperand(1);
       Lane = M - NumElts;
     }
   }
-  return InstLane{U, Lane};
+  return InstLane{V, Lane};
 }
 
 static SmallVector<InstLane>
@@ -2647,8 +2647,7 @@ generateInstLaneVectorFromOperand(ArrayRef<InstLane> Item, int Op) {
   for (InstLane IL : Item) {
     auto [U, Lane] = IL;
     InstLane OpLane =
-        U ? lookThroughShuffles(&cast<Instruction>(U->get())->getOperandUse(Op),
-                                Lane)
+        U ? lookThroughShuffles(cast<Instruction>(U)->getOperand(Op), Lane)
           : InstLane{nullptr, PoisonMaskElem};
     NItem.emplace_back(OpLane);
   }
@@ -2658,7 +2657,7 @@ generateInstLaneVectorFromOperand(ArrayRef<InstLane> Item, int Op) {
 /// Detect concat of multiple values into a vector
 static bool isFreeConcat(ArrayRef<InstLane> Item, TTI::TargetCostKind CostKind,
                          const TargetTransformInfo &TTI) {
-  auto *Ty = cast<FixedVectorType>(Item.front().first->get()->getType());
+  auto *Ty = cast<FixedVectorType>(Item.front().first->getType());
   unsigned NumElts = Ty->getNumElements();
   if (Item.size() == NumElts || NumElts == 1 || Item.size() % NumElts != 0)
     return false;
@@ -2678,39 +2677,39 @@ static bool isFreeConcat(ArrayRef<InstLane> Item, TTI::TargetCostKind CostKind,
   if (!isPowerOf2_32(NumSlices))
     return false;
   for (unsigned Slice = 0; Slice < NumSlices; ++Slice) {
-    Use *SliceV = Item[Slice * NumElts].first;
-    if (!SliceV || SliceV->get()->getType() != Ty)
+    Value *SliceV = Item[Slice * NumElts].first;
+    if (!SliceV || SliceV->getType() != Ty)
       return false;
     for (unsigned Elt = 0; Elt < NumElts; ++Elt) {
       auto [V, Lane] = Item[Slice * NumElts + Elt];
-      if (Lane != static_cast<int>(Elt) || SliceV->get() != V->get())
+      if (Lane != static_cast<int>(Elt) || SliceV != V)
         return false;
     }
   }
   return true;
 }
 
-static Value *generateNewInstTree(ArrayRef<InstLane> Item, FixedVectorType *Ty,
-                                  const SmallPtrSet<Use *, 4> &IdentityLeafs,
-                                  const SmallPtrSet<Use *, 4> &SplatLeafs,
-                                  const SmallPtrSet<Use *, 4> &ConcatLeafs,
-                                  IRBuilderBase &Builder,
-                                  const TargetTransformInfo *TTI) {
-  auto [FrontU, FrontLane] = Item.front();
+static Value *
+generateNewInstTree(ArrayRef<InstLane> Item, Use *From, FixedVectorType *Ty,
+                    const DenseSet<std::pair<Value *, Use *>> &IdentityLeafs,
+                    const DenseSet<std::pair<Value *, Use *>> &SplatLeafs,
+                    const DenseSet<std::pair<Value *, Use *>> &ConcatLeafs,
+                    IRBuilderBase &Builder, const TargetTransformInfo *TTI) {
+  auto [FrontV, FrontLane] = Item.front();
 
-  if (IdentityLeafs.contains(FrontU)) {
-    return FrontU->get();
+  if (IdentityLeafs.contains(std::make_pair(FrontV, From))) {
+    return FrontV;
   }
-  if (SplatLeafs.contains(FrontU)) {
+  if (SplatLeafs.contains(std::make_pair(FrontV, From))) {
     SmallVector<int, 16> Mask(Ty->getNumElements(), FrontLane);
-    return Builder.CreateShuffleVector(FrontU->get(), Mask);
+    return Builder.CreateShuffleVector(FrontV, Mask);
   }
-  if (ConcatLeafs.contains(FrontU)) {
+  if (ConcatLeafs.contains(std::make_pair(FrontV, From))) {
     unsigned NumElts =
-        cast<FixedVectorType>(FrontU->get()->getType())->getNumElements();
+        cast<FixedVectorType>(FrontV->getType())->getNumElements();
     SmallVector<Value *> Values(Item.size() / NumElts, nullptr);
     for (unsigned S = 0; S < Values.size(); ++S)
-      Values[S] = Item[S * NumElts].first->get();
+      Values[S] = Item[S * NumElts].first;
 
     while (Values.size() > 1) {
       NumElts *= 2;
@@ -2725,7 +2724,7 @@ static Value *generateNewInstTree(ArrayRef<InstLane> Item, FixedVectorType *Ty,
     return Values[0];
   }
 
-  auto *I = cast<Instruction>(FrontU->get());
+  auto *I = cast<Instruction>(FrontV);
   auto *II = dyn_cast<IntrinsicInst>(I);
   unsigned NumOps = I->getNumOperands() - (II ? 1 : 0);
   SmallVector<Value *> Ops(NumOps);
@@ -2736,14 +2735,14 @@ static Value *generateNewInstTree(ArrayRef<InstLane> Item, FixedVectorType *Ty,
       continue;
     }
     Ops[Idx] = generateNewInstTree(generateInstLaneVectorFromOperand(Item, Idx),
-                                   Ty, IdentityLeafs, SplatLeafs, ConcatLeafs,
-                                   Builder, TTI);
+                                   &I->getOperandUse(Idx), Ty, IdentityLeafs,
+                                   SplatLeafs, ConcatLeafs, Builder, TTI);
   }
 
   SmallVector<Value *, 8> ValueList;
   for (const auto &Lane : Item)
     if (Lane.first)
-      ValueList.push_back(Lane.first->get());
+      ValueList.push_back(Lane.first);
 
   Type *DstTy =
       FixedVectorType::get(I->getType()->getScalarType(), Ty->getNumElements());
@@ -2791,22 +2790,24 @@ bool VectorCombine::foldShuffleToIdentity(Instruction &I) {
 
   SmallVector<InstLane> Start(Ty->getNumElements());
   for (unsigned M = 0, E = Ty->getNumElements(); M < E; ++M)
-    Start[M] = lookThroughShuffles(&*I.use_begin(), M);
+    Start[M] = lookThroughShuffles(&I, M);
 
-  SmallVector<SmallVector<InstLane>> Worklist;
-  Worklist.push_back(Start);
-  SmallPtrSet<Use *, 4> IdentityLeafs, SplatLeafs, ConcatLeafs;
+  SmallVector<std::pair<SmallVector<InstLane>, Use *>> Worklist;
+  Worklist.push_back(std::make_pair(Start, &*I.use_begin()));
+  DenseSet<std::pair<Value *, Use *>> IdentityLeafs, SplatLeafs, ConcatLeafs;
   unsigned NumVisited = 0;
 
   while (!Worklist.empty()) {
     if (++NumVisited > MaxInstrsToScan)
       return false;
 
-    SmallVector<InstLane> Item = Worklist.pop_back_val();
-    auto [FrontU, FrontLane] = Item.front();
+    auto ItemFrom = Worklist.pop_back_val();
+    auto Item = ItemFrom.first;
+    auto From = ItemFrom.second;
+    auto [FrontV, FrontLane] = Item.front();
 
     // If we found an undef first lane then bail out to keep things simple.
-    if (!FrontU)
+    if (!FrontV)
       return false;
 
     // Helper to peek through bitcasts to the same value.
@@ -2817,46 +2818,46 @@ bool VectorCombine::foldShuffleToIdentity(Instruction &I) {
 
     // Look for an identity value.
     if (FrontLane == 0 &&
-        cast<FixedVectorType>(FrontU->get()->getType())->getNumElements() ==
+        cast<FixedVectorType>(FrontV->getType())->getNumElements() ==
             Ty->getNumElements() &&
         all_of(drop_begin(enumerate(Item)), [IsEquiv, Item](const auto &E) {
-          Value *FrontV = Item.front().first->get();
-          return !E.value().first || (IsEquiv(E.value().first->get(), FrontV) &&
+          Value *FrontV = Item.front().first;
+          return !E.value().first || (IsEquiv(E.value().first, FrontV) &&
                                       E.value().second == (int)E.index());
         })) {
-      IdentityLeafs.insert(FrontU);
+      IdentityLeafs.insert(std::make_pair(FrontV, From));
       continue;
     }
     // Look for constants, for the moment only supporting constant splats.
-    if (auto *C = dyn_cast<Constant>(FrontU);
+    if (auto *C = dyn_cast<Constant>(FrontV);
         C && C->getSplatValue() &&
         all_of(drop_begin(Item), [Item](InstLane &IL) {
-          Value *FrontV = Item.front().first->get();
-          Use *U = IL.first;
-          return !U || (isa<Constant>(U->get()) &&
-                        cast<Constant>(U->get())->getSplatValue() ==
+          Value *FrontV = Item.front().first;
+          Value *V = IL.first;
+          return !V || (isa<Constant>(V) &&
+                        cast<Constant>(V)->getSplatValue() ==
                             cast<Constant>(FrontV)->getSplatValue());
         })) {
-      SplatLeafs.insert(FrontU);
+      SplatLeafs.insert(std::make_pair(FrontV, From));
       continue;
     }
     // Look for a splat value.
     if (all_of(drop_begin(Item), [Item](InstLane &IL) {
-          auto [FrontU, FrontLane] = Item.front();
-          auto [U, Lane] = IL;
-          return !U || (U->get() == FrontU->get() && Lane == FrontLane);
+          auto [FrontV, FrontLane] = Item.front();
+          auto [V, Lane] = IL;
+          return !V || (V == FrontV && Lane == FrontLane);
         })) {
-      SplatLeafs.insert(FrontU);
+      SplatLeafs.insert(std::make_pair(FrontV, From));
       continue;
     }
 
     // We need each element to be the same type of value, and check that each
     // element has a single use.
     auto CheckLaneIsEquivalentToFirst = [Item](InstLane IL) {
-      Value *FrontV = Item.front().first->get();
+      Value *FrontV = Item.front().first;
       if (!IL.first)
         return true;
-      Value *V = IL.first->get();
+      Value *V = IL.first;
       if (auto *I = dyn_cast<Instruction>(V); I && !I->hasOneUse())
         return false;
       if (V->getValueID() != FrontV->getValueID())
@@ -2883,55 +2884,63 @@ bool VectorCombine::foldShuffleToIdentity(Instruction &I) {
     };
     if (all_of(drop_begin(Item), CheckLaneIsEquivalentToFirst)) {
       // Check the operator is one that we support.
-      if (isa<BinaryOperator, CmpInst>(FrontU)) {
+      if (isa<BinaryOperator, CmpInst>(FrontV)) {
         //  We exclude div/rem in case they hit UB from poison lanes.
-        if (auto *BO = dyn_cast<BinaryOperator>(FrontU);
+        if (auto *BO = dyn_cast<BinaryOperator>(FrontV);
             BO && BO->isIntDivRem())
           return false;
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 0));
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 1));
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 0),
+                              &cast<Instruction>(FrontV)->getOperandUse(0));
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 1),
+                              &cast<Instruction>(FrontV)->getOperandUse(1));
         continue;
       } else if (isa<UnaryOperator, TruncInst, ZExtInst, SExtInst, FPToSIInst,
-                     FPToUIInst, SIToFPInst, UIToFPInst>(FrontU)) {
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 0));
+                     FPToUIInst, SIToFPInst, UIToFPInst>(FrontV)) {
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 0),
+                              &cast<Instruction>(FrontV)->getOperandUse(0));
         continue;
-      } else if (auto *BitCast = dyn_cast<BitCastInst>(FrontU)) {
+      } else if (auto *BitCast = dyn_cast<BitCastInst>(FrontV)) {
         // TODO: Handle vector widening/narrowing bitcasts.
         auto *DstTy = dyn_cast<FixedVectorType>(BitCast->getDestTy());
         auto *SrcTy = dyn_cast<FixedVectorType>(BitCast->getSrcTy());
         if (DstTy && SrcTy &&
             SrcTy->getNumElements() == DstTy->getNumElements()) {
-          Worklist.push_back(generateInstLaneVectorFromOperand(Item, 0));
+          Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 0),
+                                &BitCast->getOperandUse(0));
           continue;
         }
-      } else if (isa<SelectInst>(FrontU)) {
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 0));
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 1));
-        Worklist.push_back(generateInstLaneVectorFromOperand(Item, 2));
+      } else if (auto *Sel = dyn_cast<SelectInst>(FrontV)) {
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 0),
+                              &Sel->getOperandUse(0));
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 1),
+                              &Sel->getOperandUse(1));
+        Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, 2),
+                              &Sel->getOperandUse(2));
         continue;
-      } else if (auto *II = dyn_cast<IntrinsicInst>(FrontU);
+      } else if (auto *II = dyn_cast<IntrinsicInst>(FrontV);
                  II && isTriviallyVectorizable(II->getIntrinsicID()) &&
                  !II->hasOperandBundles()) {
         for (unsigned Op = 0, E = II->getNumOperands() - 1; Op < E; Op++) {
           if (isVectorIntrinsicWithScalarOpAtArg(II->getIntrinsicID(), Op,
                                                  &TTI)) {
             if (!all_of(drop_begin(Item), [Item, Op](InstLane &IL) {
-                  Value *FrontV = Item.front().first->get();
-                  Use *U = IL.first;
-                  return !U || (cast<Instruction>(U->get())->getOperand(Op) ==
+                  Value *FrontV = Item.front().first;
+                  Value *V = IL.first;
+                  return !V || (cast<Instruction>(V)->getOperand(Op) ==
                                 cast<Instruction>(FrontV)->getOperand(Op));
                 }))
               return false;
             continue;
           }
-          Worklist.push_back(generateInstLaneVectorFromOperand(Item, Op));
+          Worklist.emplace_back(generateInstLaneVectorFromOperand(Item, Op),
+                                &cast<Instruction>(FrontV)->getOperandUse(Op));
         }
         continue;
       }
     }
 
     if (isFreeConcat(Item, CostKind, TTI)) {
-      ConcatLeafs.insert(FrontU);
+      ConcatLeafs.insert(std::make_pair(FrontV, From));
       continue;
     }
 
@@ -2946,8 +2955,8 @@ bool VectorCombine::foldShuffleToIdentity(Instruction &I) {
   // If we got this far, we know the shuffles are superfluous and can be
   // removed. Scan through again and generate the new tree of instructions.
   Builder.SetInsertPoint(&I);
-  Value *V = generateNewInstTree(Start, Ty, IdentityLeafs, SplatLeafs,
-                                 ConcatLeafs, Builder, &TTI);
+  Value *V = generateNewInstTree(Start, &*I.use_begin(), Ty, IdentityLeafs,
+                                 SplatLeafs, ConcatLeafs, Builder, &TTI);
   replaceValue(I, *V);
   return true;
 }

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
@@ -1226,5 +1226,137 @@ define <32 x half> @cast_types(<32 x i16> %wide.vec) {
   ret <32 x half> %interleaved.vec
 }
 
+define i32 @shuffle_different_lanes(<2 x i64> %0) {
+; CHECK-LABEL: @shuffle_different_lanes(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[SHUFFLE:%.*]] = shufflevector <2 x i64> [[TMP2:%.*]], <2 x i64> poison, <4 x i32> <i32 0, i32 0, i32 1, i32 1>
+; CHECK-NEXT:    [[CONV:%.*]] = trunc <4 x i64> [[SHUFFLE]] to <4 x i16>
+; CHECK-NEXT:    [[TMP4:%.*]] = trunc <2 x i64> [[TMP2]] to <2 x i16>
+; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <4 x i16> [[CONV]], <4 x i16> poison, <2 x i32> <i32 2, i32 2>
+; CHECK-NEXT:    [[SHUFFLE_I:%.*]] = sub <2 x i16> [[TMP4]], [[TMP5]]
+; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i16> [[SHUFFLE_I]] to i32
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+entry:
+  %shuffle = shufflevector <2 x i64> %0, <2 x i64> poison, <4 x i32> <i32 0, i32 0, i32 1, i32 1>
+  %conv = trunc <4 x i64> %shuffle to <4 x i16>
+  %vecinit4.i = shufflevector <4 x i16> %conv, <4 x i16> poison, <4 x i32> <i32 2, i32 poison, i32 2, i32 poison>
+  %sub.i = sub <4 x i16> %conv, %vecinit4.i
+  %shuffle.i = shufflevector <4 x i16> %sub.i, <4 x i16> poison, <2 x i32> <i32 0, i32 2>
+  %1 = bitcast <2 x i16> %shuffle.i to i32
+  ret i32 %1
+}
+
+define <48 x i8> @concat_splats(<64 x i8> %wide.vec, <64 x i8> %wide.vec117) {
+; CHECK-LABEL: @concat_splats(
+; CHECK-NEXT:    [[STRIDED_VEC:%.*]] = shufflevector <64 x i8> [[WIDE_VEC:%.*]], <64 x i8> poison, <16 x i32> <i32 0, i32 4, i32 8, i32 12, i32 16, i32 20, i32 24, i32 28, i32 32, i32 36, i32 40, i32 44, i32 48, i32 52, i32 56, i32 60>
+; CHECK-NEXT:    [[STRIDED_VEC114:%.*]] = shufflevector <64 x i8> [[WIDE_VEC]], <64 x i8> poison, <16 x i32> <i32 1, i32 5, i32 9, i32 13, i32 17, i32 21, i32 25, i32 29, i32 33, i32 37, i32 41, i32 45, i32 49, i32 53, i32 57, i32 61>
+; CHECK-NEXT:    [[STRIDED_VEC115:%.*]] = shufflevector <64 x i8> [[WIDE_VEC]], <64 x i8> poison, <16 x i32> <i32 2, i32 6, i32 10, i32 14, i32 18, i32 22, i32 26, i32 30, i32 34, i32 38, i32 42, i32 46, i32 50, i32 54, i32 58, i32 62>
+; CHECK-NEXT:    [[STRIDED_VEC116:%.*]] = shufflevector <64 x i8> [[WIDE_VEC]], <64 x i8> poison, <16 x i32> <i32 3, i32 7, i32 11, i32 15, i32 19, i32 23, i32 27, i32 31, i32 35, i32 39, i32 43, i32 47, i32 51, i32 55, i32 59, i32 63>
+; CHECK-NEXT:    [[TMP1:%.*]] = zext <16 x i8> [[STRIDED_VEC]] to <16 x i32>
+; CHECK-NEXT:    [[TMP2:%.*]] = mul nuw nsw <16 x i32> [[TMP1]], splat (i32 3)
+; CHECK-NEXT:    [[TMP3:%.*]] = zext <16 x i8> [[STRIDED_VEC114]] to <16 x i32>
+; CHECK-NEXT:    [[TMP4:%.*]] = zext <16 x i8> [[STRIDED_VEC115]] to <16 x i32>
+; CHECK-NEXT:    [[TMP5:%.*]] = zext <16 x i8> [[STRIDED_VEC116]] to <16 x i32>
+; CHECK-NEXT:    [[TMP6:%.*]] = mul nuw nsw <16 x i32> [[TMP5]], splat (i32 3)
+; CHECK-NEXT:    [[TMP7:%.*]] = add nuw nsw <16 x i32> [[TMP4]], splat (i32 2)
+; CHECK-NEXT:    [[TMP8:%.*]] = add nuw nsw <16 x i32> [[TMP7]], [[TMP6]]
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr <16 x i32> [[TMP8]], splat (i32 2)
+; CHECK-NEXT:    [[STRIDED_VEC118:%.*]] = shufflevector <64 x i8> [[WIDE_VEC117:%.*]], <64 x i8> poison, <16 x i32> <i32 0, i32 4, i32 8, i32 12, i32 16, i32 20, i32 24, i32 28, i32 32, i32 36, i32 40, i32 44, i32 48, i32 52, i32 56, i32 60>
+; CHECK-NEXT:    [[STRIDED_VEC119:%.*]] = shufflevector <64 x i8> [[WIDE_VEC117]], <64 x i8> poison, <16 x i32> <i32 1, i32 5, i32 9, i32 13, i32 17, i32 21, i32 25, i32 29, i32 33, i32 37, i32 41, i32 45, i32 49, i32 53, i32 57, i32 61>
+; CHECK-NEXT:    [[STRIDED_VEC120:%.*]] = shufflevector <64 x i8> [[WIDE_VEC117]], <64 x i8> poison, <16 x i32> <i32 2, i32 6, i32 10, i32 14, i32 18, i32 22, i32 26, i32 30, i32 34, i32 38, i32 42, i32 46, i32 50, i32 54, i32 58, i32 62>
+; CHECK-NEXT:    [[STRIDED_VEC121:%.*]] = shufflevector <64 x i8> [[WIDE_VEC117]], <64 x i8> poison, <16 x i32> <i32 3, i32 7, i32 11, i32 15, i32 19, i32 23, i32 27, i32 31, i32 35, i32 39, i32 43, i32 47, i32 51, i32 55, i32 59, i32 63>
+; CHECK-NEXT:    [[TMP10:%.*]] = zext <16 x i8> [[STRIDED_VEC118]] to <16 x i32>
+; CHECK-NEXT:    [[TMP11:%.*]] = mul nuw nsw <16 x i32> [[TMP10]], splat (i32 3)
+; CHECK-NEXT:    [[TMP12:%.*]] = zext <16 x i8> [[STRIDED_VEC119]] to <16 x i32>
+; CHECK-NEXT:    [[TMP13:%.*]] = zext <16 x i8> [[STRIDED_VEC120]] to <16 x i32>
+; CHECK-NEXT:    [[TMP14:%.*]] = zext <16 x i8> [[STRIDED_VEC121]] to <16 x i32>
+; CHECK-NEXT:    [[TMP15:%.*]] = mul nuw nsw <16 x i32> [[TMP14]], splat (i32 3)
+; CHECK-NEXT:    [[TMP16:%.*]] = add nuw nsw <16 x i32> [[TMP13]], splat (i32 2)
+; CHECK-NEXT:    [[TMP17:%.*]] = add nuw nsw <16 x i32> [[TMP16]], [[TMP15]]
+; CHECK-NEXT:    [[TMP18:%.*]] = lshr <16 x i32> [[TMP17]], splat (i32 2)
+; CHECK-NEXT:    [[TMP19:%.*]] = mul nuw nsw <16 x i32> [[TMP9]], splat (i32 3)
+; CHECK-NEXT:    [[TMP20:%.*]] = add nuw nsw <16 x i32> [[TMP19]], splat (i32 2)
+; CHECK-NEXT:    [[TMP21:%.*]] = add nuw nsw <16 x i32> [[TMP20]], [[TMP18]]
+; CHECK-NEXT:    [[TMP22:%.*]] = lshr <16 x i32> [[TMP21]], splat (i32 2)
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc nuw <16 x i32> [[TMP22]] to <16 x i8>
+; CHECK-NEXT:    [[TMP24:%.*]] = shufflevector <16 x i32> [[TMP3]], <16 x i32> [[TMP3]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+; CHECK-NEXT:    [[TMP25:%.*]] = add nuw nsw <32 x i32> [[TMP24]], <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+; CHECK-NEXT:    [[TMP26:%.*]] = shufflevector <16 x i32> [[TMP2]], <16 x i32> [[TMP4]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+; CHECK-NEXT:    [[TMP27:%.*]] = add nuw nsw <32 x i32> [[TMP25]], [[TMP26]]
+; CHECK-NEXT:    [[TMP28:%.*]] = lshr <32 x i32> [[TMP27]], <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+; CHECK-NEXT:    [[TMP29:%.*]] = mul nuw nsw <32 x i32> [[TMP28]], splat (i32 3)
+; CHECK-NEXT:    [[TMP30:%.*]] = add nuw nsw <32 x i32> [[TMP29]], splat (i32 2)
+; CHECK-NEXT:    [[TMP31:%.*]] = shufflevector <16 x i32> [[TMP12]], <16 x i32> [[TMP12]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+; CHECK-NEXT:    [[TMP32:%.*]] = add nuw nsw <32 x i32> [[TMP31]], <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+; CHECK-NEXT:    [[TMP33:%.*]] = shufflevector <16 x i32> [[TMP11]], <16 x i32> [[TMP13]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+; CHECK-NEXT:    [[TMP34:%.*]] = add nuw nsw <32 x i32> [[TMP32]], [[TMP33]]
+; CHECK-NEXT:    [[TMP35:%.*]] = lshr <32 x i32> [[TMP34]], <i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
+; CHECK-NEXT:    [[TMP36:%.*]] = add nuw nsw <32 x i32> [[TMP30]], [[TMP35]]
+; CHECK-NEXT:    [[TMP37:%.*]] = lshr <32 x i32> [[TMP36]], splat (i32 2)
+; CHECK-NEXT:    [[TMP38:%.*]] = trunc nuw <32 x i32> [[TMP37]] to <32 x i8>
+; CHECK-NEXT:    [[TMP39:%.*]] = shufflevector <16 x i8> [[TMP23]], <16 x i8> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[INTERLEAVED_VEC:%.*]] = shufflevector <32 x i8> [[TMP38]], <32 x i8> [[TMP39]], <48 x i32> <i32 0, i32 16, i32 32, i32 1, i32 17, i32 33, i32 2, i32 18, i32 34, i32 3, i32 19, i32 35, i32 4, i32 20, i32 36, i32 5, i32 21, i32 37, i32 6, i32 22, i32 38, i32 7, i32 23, i32 39, i32 8, i32 24, i32 40, i32 9, i32 25, i32 41, i32 10, i32 26, i32 42, i32 11, i32 27, i32 43, i32 12, i32 28, i32 44, i32 13, i32 29, i32 45, i32 14, i32 30, i32 46, i32 15, i32 31, i32 47>
+; CHECK-NEXT:    ret <48 x i8> [[INTERLEAVED_VEC]]
+;
+  %strided.vec = shufflevector <64 x i8> %wide.vec, <64 x i8> poison, <16 x i32> <i32 0, i32 4, i32 8, i32 12, i32 16, i32 20, i32 24, i32 28, i32 32, i32 36, i32 40, i32 44, i32 48, i32 52, i32 56, i32 60>
+  %strided.vec114 = shufflevector <64 x i8> %wide.vec, <64 x i8> poison, <16 x i32> <i32 1, i32 5, i32 9, i32 13, i32 17, i32 21, i32 25, i32 29, i32 33, i32 37, i32 41, i32 45, i32 49, i32 53, i32 57, i32 61>
+  %strided.vec115 = shufflevector <64 x i8> %wide.vec, <64 x i8> poison, <16 x i32> <i32 2, i32 6, i32 10, i32 14, i32 18, i32 22, i32 26, i32 30, i32 34, i32 38, i32 42, i32 46, i32 50, i32 54, i32 58, i32 62>
+  %strided.vec116 = shufflevector <64 x i8> %wide.vec, <64 x i8> poison, <16 x i32> <i32 3, i32 7, i32 11, i32 15, i32 19, i32 23, i32 27, i32 31, i32 35, i32 39, i32 43, i32 47, i32 51, i32 55, i32 59, i32 63>
+  %22 = zext <16 x i8> %strided.vec to <16 x i32>
+  %23 = mul nuw nsw <16 x i32> %22, splat (i32 3)
+  %24 = zext <16 x i8> %strided.vec114 to <16 x i32>
+  %25 = add nuw nsw <16 x i32> %24, splat (i32 2)
+  %26 = add nuw nsw <16 x i32> %25, %23
+  %27 = lshr <16 x i32> %26, splat (i32 2)
+  %28 = zext <16 x i8> %strided.vec115 to <16 x i32>
+  %29 = add nuw nsw <16 x i32> %24, splat (i32 1)
+  %30 = add nuw nsw <16 x i32> %29, %28
+  %31 = lshr <16 x i32> %30, splat (i32 1)
+  %32 = zext <16 x i8> %strided.vec116 to <16 x i32>
+  %33 = mul nuw nsw <16 x i32> %32, splat (i32 3)
+  %34 = add nuw nsw <16 x i32> %28, splat (i32 2)
+  %35 = add nuw nsw <16 x i32> %34, %33
+  %36 = lshr <16 x i32> %35, splat (i32 2)
+  %strided.vec118 = shufflevector <64 x i8> %wide.vec117, <64 x i8> poison, <16 x i32> <i32 0, i32 4, i32 8, i32 12, i32 16, i32 20, i32 24, i32 28, i32 32, i32 36, i32 40, i32 44, i32 48, i32 52, i32 56, i32 60>
+  %strided.vec119 = shufflevector <64 x i8> %wide.vec117, <64 x i8> poison, <16 x i32> <i32 1, i32 5, i32 9, i32 13, i32 17, i32 21, i32 25, i32 29, i32 33, i32 37, i32 41, i32 45, i32 49, i32 53, i32 57, i32 61>
+  %strided.vec120 = shufflevector <64 x i8> %wide.vec117, <64 x i8> poison, <16 x i32> <i32 2, i32 6, i32 10, i32 14, i32 18, i32 22, i32 26, i32 30, i32 34, i32 38, i32 42, i32 46, i32 50, i32 54, i32 58, i32 62>
+  %strided.vec121 = shufflevector <64 x i8> %wide.vec117, <64 x i8> poison, <16 x i32> <i32 3, i32 7, i32 11, i32 15, i32 19, i32 23, i32 27, i32 31, i32 35, i32 39, i32 43, i32 47, i32 51, i32 55, i32 59, i32 63>
+  %37 = zext <16 x i8> %strided.vec118 to <16 x i32>
+  %38 = mul nuw nsw <16 x i32> %37, splat (i32 3)
+  %39 = zext <16 x i8> %strided.vec119 to <16 x i32>
+  %40 = add nuw nsw <16 x i32> %39, splat (i32 2)
+  %41 = add nuw nsw <16 x i32> %40, %38
+  %42 = lshr <16 x i32> %41, splat (i32 2)
+  %43 = zext <16 x i8> %strided.vec120 to <16 x i32>
+  %44 = add nuw nsw <16 x i32> %39, splat (i32 1)
+  %45 = add nuw nsw <16 x i32> %44, %43
+  %46 = lshr <16 x i32> %45, splat (i32 1)
+  %47 = zext <16 x i8> %strided.vec121 to <16 x i32>
+  %48 = mul nuw nsw <16 x i32> %47, splat (i32 3)
+  %49 = add nuw nsw <16 x i32> %43, splat (i32 2)
+  %50 = add nuw nsw <16 x i32> %49, %48
+  %51 = lshr <16 x i32> %50, splat (i32 2)
+  %52 = mul nuw nsw <16 x i32> %27, splat (i32 3)
+  %53 = add nuw nsw <16 x i32> %52, splat (i32 2)
+  %54 = add nuw nsw <16 x i32> %53, %42
+  %55 = lshr <16 x i32> %54, splat (i32 2)
+  %56 = trunc nuw <16 x i32> %55 to <16 x i8>
+  %57 = mul nuw nsw <16 x i32> %31, splat (i32 3)
+  %58 = add nuw nsw <16 x i32> %57, splat (i32 2)
+  %59 = add nuw nsw <16 x i32> %58, %46
+  %60 = lshr <16 x i32> %59, splat (i32 2)
+  %61 = trunc nuw <16 x i32> %60 to <16 x i8>
+  %62 = mul nuw nsw <16 x i32> %36, splat (i32 3)
+  %63 = add nuw nsw <16 x i32> %62, splat (i32 2)
+  %64 = add nuw nsw <16 x i32> %63, %51
+  %65 = lshr <16 x i32> %64, splat (i32 2)
+  %66 = trunc nuw <16 x i32> %65 to <16 x i8>
+  %67 = shufflevector <16 x i8> %56, <16 x i8> %61, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %68 = shufflevector <16 x i8> %66, <16 x i8> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+  %interleaved.vec = shufflevector <32 x i8> %67, <32 x i8> %68, <48 x i32> <i32 0, i32 16, i32 32, i32 1, i32 17, i32 33, i32 2, i32 18, i32 34, i32 3, i32 19, i32 35, i32 4, i32 20, i32 36, i32 5, i32 21, i32 37, i32 6, i32 22, i32 38, i32 7, i32 23, i32 39, i32 8, i32 24, i32 40, i32 9, i32 25, i32 41, i32 10, i32 26, i32 42, i32 11, i32 27, i32 43, i32 12, i32 28, i32 44, i32 13, i32 29, i32 45, i32 14, i32 30, i32 46, i32 15, i32 31, i32 47>
+  ret <48 x i8> %interleaved.vec
+}
+
 declare <4 x i64> @llvm.fshl.v4i64(<4 x i64>, <4 x i64>, <4 x i64>)
 declare void @use(<4 x i8>)


### PR DESCRIPTION
Backport of llvm/llvm-project@fd40c606652137706bc336ef80ed1814ab3d3680 (llvm/llvm-project#188989) to the LLVM 21 branch, same defect as JuliaLang/llvm-project#55 / JuliaLang/julia#62420. The Julia-level reproducer from that issue happens not to form the trigger IR shape on LLVM 21, but the defect is present: unpatched `opt -passes=vector-combine` from this branch miscompiles the reduced testcase (`fmul <2 x float> %0, %0` instead of splatting lane 1), and produces the correct splat with this patch.

The code applies cleanly on this branch. The LoongArch test update was dropped (test does not exist here) and the CHECK lines for the new `shuffle_different_lanes` test were regenerated (this branch does not perform that independently-correct fold that main does). `llvm-lit llvm/test/Transforms/VectorCombine/` passes (62/62 supported).